### PR TITLE
Add camel stable

### DIFF
--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -18,8 +18,10 @@ class CamelStable {
 
         let index = 0;
 
-        const variation = 30;
-        const uniformCenters = Array.from(new Array(this._numberOfCamels), (e, i) => (100 / this._numberOfCamels) * (i + 1));
+        const variation = 20;
+        const minimumLevel = 5;
+        const maximumLevel = 100;
+        const uniformCenters = Array.from(new Array(this._numberOfCamels), (e, i) => minimumLevel + ((maximumLevel - minimumLevel) / this._numberOfCamels) * (i));
 
         if (firstTimeSetUp) {
             uniformCenters.forEach(center => {

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -8,6 +8,8 @@ class CamelStable {
     private _camelInformationLength = 10;
     private _numberOfCamels = 25;
 
+    public camels: Camel[] = [];
+
     public populateStable() {
         let firstTimeSetUp = false;
         if (!GameState.stableSeed) {
@@ -18,14 +20,13 @@ class CamelStable {
         const seed = GameState.stableSeed;
 
         let index = 0;
-        let camels: Camel[] = [];
 
         const variation = 30;
         const uniformCenters = Array.from(new Array(this._numberOfCamels), (e, i) => (100 / this._numberOfCamels) * (i + 1));
 
         if (firstTimeSetUp) {
             uniformCenters.forEach(center => {
-                camels.push(
+                this.camels.push(
                     this._camelCreator.createSeededCamel([
                         this.generateRandomNumber(center, variation),
                         this.generateRandomNumber(center, variation),
@@ -61,7 +62,7 @@ class CamelStable {
             index += this._camelInformationLength;
         };
 
-        new Array(this._numberOfCamels).forEach(quality => populateCamelArray(camels));
+        new Array(this._numberOfCamels).forEach(quality => populateCamelArray(this.camels));
 
         return;
     }

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -69,7 +69,7 @@ class CamelStable {
             index += this._camelInformationLength;
         };
 
-        new Array(this._numberOfCamels).forEach(quality => populateCamelArray(this.camels));
+        new Array(this._numberOfCamels).forEach(e => populateCamelArray(this.camels));
 
         return;
     }

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -1,0 +1,67 @@
+class CamelStable {
+    constructor(
+        private readonly _camelCreator: CamelCreator
+        ) {
+    }
+
+    public populateStable() {
+        if (!GameState.stableSeed) {
+            GameState.stableSeed = this.generateSeed();
+        }
+
+        const seed = GameState.stableSeed;
+        const camelInformationLength = 10;
+        
+        let index = 0;
+        let easyCamelCount = 10;
+        let mediumCamelCount = 10;
+        let hardCamelCount = 10;
+        
+        let easyCamels: Camel[] = [];
+        let mediumCamels: Camel[] = [];
+        let hardCamels: Camel[] = [];
+
+        const populateCamelArray = (quality: InitCamelQuality, camelArray: Camel[]) => {
+            const seedPart = seed.slice(index * camelInformationLength, (1 + index) * camelInformationLength);
+
+            camelArray.push(
+                this._camelCreator.createSeededCamel([
+                    ((quality + 1) / 10) * parseInt(seed.slice(0,2), 36) / (36 ** 2),
+                    parseInt(seedPart.slice(2,4), 36) / (36 ** 2),
+                    parseInt(seedPart.slice(4,6), 36) / (36 ** 2),
+                    parseInt(seedPart.slice(6,7), 36) / 36,
+                    parseInt(seedPart.slice(7,8), 36) / 36,
+                    parseInt(seedPart.slice(8,9), 36) / 36,
+                    parseInt(seedPart.slice(8,9), 36) / 36
+                ])
+            );
+
+            index += camelInformationLength;
+        };
+
+        new Array(easyCamelCount).fill(InitCamelQuality.High).forEach(quality => populateCamelArray(quality, easyCamels));
+        new Array(mediumCamelCount).fill(InitCamelQuality.Cpu1).forEach(quality => populateCamelArray(quality, mediumCamels));
+        new Array(hardCamelCount).fill(InitCamelQuality.Cpu5).forEach(quality => populateCamelArray(quality, hardCamels));
+    }
+
+    public static GetGeneralWaste: () => Camel = () => {
+        const levelCurve = new DefaultLevelCurve();
+        return new Camel(++GameState.lastUsedId, {
+            colour: "#fff",
+            name: "General Waste",
+            skills: {
+                agility: new CamelSkill(CamelSkillType.agility, levelCurve, 0, levelCurve.getXpRequiredForLevel(2)),
+                sprintSpeed: new CamelSkill(CamelSkillType.sprintSpeed, levelCurve, 0, levelCurve.getXpRequiredForLevel(50)),
+                stamina: new CamelSkill(CamelSkillType.stamina, levelCurve, 0, levelCurve.getXpRequiredForLevel(50)),
+            },
+            temperament: CamelTemperament.Calm,
+            unspentXp: 0,
+            achievementsUnlocked: 0,
+        });
+    };
+
+    private generateSeed(length: number = 700, radix: number = 36): string {
+        return "x".repeat(length).replace(/x/g, (char) => 
+            Math.floor(Math.random() * radix).toString(radix));  
+    }
+}

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -1,8 +1,12 @@
 class CamelStable {
     constructor(
         private readonly _camelCreator: CamelCreator
-        ) {
+    ) {
     }
+
+    private _seedRadix = 36;
+    private _camelInformationLength = 10;
+    private _numberOfCamels = 25;
 
     public populateStable() {
         let firstTimeSetUp = false;
@@ -12,65 +16,54 @@ class CamelStable {
         }
 
         const seed = GameState.stableSeed;
-        const camelInformationLength = 10;
-        
+
         let index = 0;
         let camels: Camel[] = [];
 
-        if (!firstTimeSetUp) {
-            const populateCamelArray = (camelArray: Camel[]) => {
-                const radix = 36
-                const seedPart = seed.slice(index * camelInformationLength, (1 + index) * camelInformationLength);
-                const maxLevel = (new DefaultLevelCurve()).maxSkillLevel;
+        const variation = 30;
+        const uniformCenters = Array.from(new Array(this._numberOfCamels), (e, i) => (100 / this._numberOfCamels) * (i + 1));
 
-                camelArray.push(
+        if (firstTimeSetUp) {
+            uniformCenters.forEach(center => {
+                camels.push(
                     this._camelCreator.createSeededCamel([
-                        maxLevel * parseInt(seedPart.slice(0,2), radix) / (radix ** 2),
-                        maxLevel * parseInt(seedPart.slice(2,4), radix) / (radix ** 2),
-                        maxLevel * parseInt(seedPart.slice(4,6), radix) / (radix ** 2),
-                        parseInt(seedPart.slice(6,7), radix) / radix,
-                        parseInt(seedPart.slice(7,8), radix) / radix,
-                        parseInt(seedPart.slice(8,9), radix) / radix,
-                        parseInt(seedPart.slice(8,9), radix) / radix,
+                        this.generateRandomNumber(center, variation),
+                        this.generateRandomNumber(center, variation),
+                        this.generateRandomNumber(center, variation),
+                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
+                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
+                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
+                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
                     ])
                 );
+            });
 
-                index += camelInformationLength;
-            };
-
-            new Array(30).forEach(quality => populateCamelArray(camels));
+            return;
         }
 
-        let easyCamelCount = 10;
-        let mediumCamelCount = 10;
-        let hardCamelCount = 10;
-        
-        let easyCamels: Camel[] = [];
-        let mediumCamels: Camel[] = [];
-        let hardCamels: Camel[] = [];
-
-        const populateQualityCamelArray = (quality: InitCamelQuality, camelArray: Camel[]) => {
+        const populateCamelArray = (camelArray: Camel[]) => {
             const radix = 36
-            const seedPart = seed.slice(index * camelInformationLength, (1 + index) * camelInformationLength);
+            const seedPart = seed.slice(index * this._camelInformationLength, (1 + index) * this._camelInformationLength);
+            const maxLevel = (new DefaultLevelCurve()).maxSkillLevel;
 
             camelArray.push(
                 this._camelCreator.createSeededCamel([
-                    ((quality + 1) / 10) * parseInt(seedPart.slice(0,2), radix) / (radix ** 2),
-                    ((quality + 1) / 10) * parseInt(seedPart.slice(2,4), radix) / (radix ** 2),
-                    ((quality + 1) / 10) * parseInt(seedPart.slice(4,6), radix) / (radix ** 2),
-                    parseInt(seedPart.slice(6,7), radix) / radix,
-                    parseInt(seedPart.slice(7,8), radix) / radix,
-                    parseInt(seedPart.slice(8,9), radix) / radix,
-                    parseInt(seedPart.slice(8,9), radix) / radix,
+                    maxLevel * parseInt(seedPart.slice(0, 2), radix) / (radix ** 2),
+                    maxLevel * parseInt(seedPart.slice(2, 4), radix) / (radix ** 2),
+                    maxLevel * parseInt(seedPart.slice(4, 6), radix) / (radix ** 2),
+                    parseInt(seedPart.slice(6, 7), radix) / radix,
+                    parseInt(seedPart.slice(7, 8), radix) / radix,
+                    parseInt(seedPart.slice(8, 9), radix) / radix,
+                    parseInt(seedPart.slice(9, 10), radix) / radix,
                 ])
             );
 
-            index += camelInformationLength;
+            index += this._camelInformationLength;
         };
 
-        new Array(easyCamelCount).fill(InitCamelQuality.High).forEach(quality => populateQualityCamelArray(quality, easyCamels));
-        new Array(mediumCamelCount).fill(InitCamelQuality.Cpu1).forEach(quality => populateQualityCamelArray(quality, mediumCamels));
-        new Array(hardCamelCount).fill(InitCamelQuality.Cpu5).forEach(quality => populateQualityCamelArray(quality, hardCamels));
+        new Array(this._numberOfCamels).forEach(quality => populateCamelArray(camels));
+
+        return;
     }
 
     public static GetGeneralWaste: () => Camel = () => {
@@ -90,7 +83,12 @@ class CamelStable {
     };
 
     private generateSeed(length: number = 700, radix: number = 36): string {
-        return "x".repeat(length).replace(/x/g, (char) => 
-            Math.floor(Math.random() * radix).toString(radix));  
+        return "x".repeat(length).replace(/x/g, (char) =>
+            Math.floor(Math.random() * radix).toString(radix));
+    }
+
+    private generateRandomNumber(center: number, plusMinusRange: number, max: number = 100, min: number = 0) {
+        const randValue = center + ((Math.random()) * 2 - 1) * plusMinusRange;
+        return Math.max(min, Math.min(max, randValue));
     }
 }

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -95,7 +95,7 @@ class CamelStable {
             Math.floor(Math.random() * radix).toString(radix));
     }
 
-    private generateRandomNumber(center: number, plusMinusRange: number, max: number = 100, min: number = 0) {
+    private generateRandomNumber(center: number, plusMinusRange: number, min: number = 1, max: number = 100) {
         const randValue = center + ((Math.random()) * 2 - 1) * plusMinusRange;
         return Math.max(min, Math.min(max, randValue));
     }

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -13,11 +13,8 @@ class CamelStable {
     public populateStable() {
         let firstTimeSetUp = false;
         if (!GameState.stableSeed) {
-            GameState.stableSeed = this.generateSeed();
             firstTimeSetUp = true;
         }
-
-        const seed = GameState.stableSeed;
 
         let index = 0;
 
@@ -26,36 +23,46 @@ class CamelStable {
 
         if (firstTimeSetUp) {
             uniformCenters.forEach(center => {
-                this.camels.push(
-                    this._camelCreator.createSeededCamel([
-                        this.generateRandomNumber(center, variation),
-                        this.generateRandomNumber(center, variation),
-                        this.generateRandomNumber(center, variation),
-                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
-                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
-                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
-                        parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix,
-                    ])
-                );
+
+                const agility = this.generateRandomNumber(center, variation); 
+                const sprintSpeed = this.generateRandomNumber(center, variation); 
+                const stamina = this.generateRandomNumber(center, variation); 
+                const colour = this.generateSeed(1);
+                const name1 = this.generateSeed(1);
+                const name2 = this.generateSeed(1);
+                const temperament = this.generateSeed(1); // unused
+
+                const camel = this._camelCreator.createSeededCamel([
+                    agility,
+                    sprintSpeed,
+                    stamina,
+                    parseInt(colour, this._seedRadix) / this._seedRadix,
+                    parseInt(name1, this._seedRadix) / this._seedRadix,
+                    parseInt(name2, this._seedRadix) / this._seedRadix,
+                    parseInt(temperament, this._seedRadix) / this._seedRadix,
+                ]);
+
+                this.camels.push(camel);
+
+                GameState.stableSeed += this._camelCreator.createSeedFromCamel(camel);
             });
 
             return;
         }
 
         const populateCamelArray = (camelArray: Camel[]) => {
-            const radix = 36
-            const seedPart = seed.slice(index * this._camelInformationLength, (1 + index) * this._camelInformationLength);
+            const seedPart = GameState.stableSeed.slice(index * this._camelInformationLength, (1 + index) * this._camelInformationLength);
             const maxLevel = (new DefaultLevelCurve()).maxSkillLevel;
 
             camelArray.push(
                 this._camelCreator.createSeededCamel([
-                    maxLevel * parseInt(seedPart.slice(0, 2), radix) / (radix ** 2),
-                    maxLevel * parseInt(seedPart.slice(2, 4), radix) / (radix ** 2),
-                    maxLevel * parseInt(seedPart.slice(4, 6), radix) / (radix ** 2),
-                    parseInt(seedPart.slice(6, 7), radix) / radix,
-                    parseInt(seedPart.slice(7, 8), radix) / radix,
-                    parseInt(seedPart.slice(8, 9), radix) / radix,
-                    parseInt(seedPart.slice(9, 10), radix) / radix,
+                    maxLevel * parseInt(seedPart.slice(0, 2), this._seedRadix) / (this._seedRadix ** 2),
+                    maxLevel * parseInt(seedPart.slice(2, 4), this._seedRadix) / (this._seedRadix ** 2),
+                    maxLevel * parseInt(seedPart.slice(4, 6), this._seedRadix) / (this._seedRadix ** 2),
+                    parseInt(seedPart.slice(6, 7), this._seedRadix) / this._seedRadix,
+                    parseInt(seedPart.slice(7, 8), this._seedRadix) / this._seedRadix,
+                    parseInt(seedPart.slice(8, 9), this._seedRadix) / this._seedRadix,
+                    parseInt(seedPart.slice(9, 10), this._seedRadix) / this._seedRadix,
                 ])
             );
 

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -54,13 +54,12 @@ class CamelStable {
 
         const populateCamelArray = (camelArray: Camel[]) => {
             const seedPart = GameState.stableSeed.slice(index * this._camelInformationLength, (1 + index) * this._camelInformationLength);
-            const maxLevel = (new DefaultLevelCurve()).maxSkillLevel;
 
             camelArray.push(
                 this._camelCreator.createSeededCamel([
-                    maxLevel * parseInt(seedPart.slice(0, 2), this._seedRadix) / (this._seedRadix ** 2),
-                    maxLevel * parseInt(seedPart.slice(2, 4), this._seedRadix) / (this._seedRadix ** 2),
-                    maxLevel * parseInt(seedPart.slice(4, 6), this._seedRadix) / (this._seedRadix ** 2),
+                    parseInt(seedPart.slice(0, 2), this._seedRadix),
+                    parseInt(seedPart.slice(2, 4), this._seedRadix),
+                    parseInt(seedPart.slice(4, 6), this._seedRadix),
                     parseInt(seedPart.slice(6, 7), this._seedRadix) / this._seedRadix,
                     parseInt(seedPart.slice(7, 8), this._seedRadix) / this._seedRadix,
                     parseInt(seedPart.slice(8, 9), this._seedRadix) / this._seedRadix,
@@ -68,10 +67,10 @@ class CamelStable {
                 ])
             );
 
-            index += this._camelInformationLength;
+            index += 1;
         };
 
-        new Array(this._numberOfCamels).forEach(e => populateCamelArray(this.camels));
+        new Array(this._numberOfCamels).fill(1).forEach(e => populateCamelArray(this.camels));
 
         return;
     }

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -5,14 +5,42 @@ class CamelStable {
     }
 
     public populateStable() {
+        let firstTimeSetUp = false;
         if (!GameState.stableSeed) {
             GameState.stableSeed = this.generateSeed();
+            firstTimeSetUp = true;
         }
 
         const seed = GameState.stableSeed;
         const camelInformationLength = 10;
         
         let index = 0;
+        let camels: Camel[] = [];
+
+        if (!firstTimeSetUp) {
+            const populateCamelArray = (camelArray: Camel[]) => {
+                const radix = 36
+                const seedPart = seed.slice(index * camelInformationLength, (1 + index) * camelInformationLength);
+                const maxLevel = (new DefaultLevelCurve()).maxSkillLevel;
+
+                camelArray.push(
+                    this._camelCreator.createSeededCamel([
+                        maxLevel * parseInt(seedPart.slice(0,2), radix) / (radix ** 2),
+                        maxLevel * parseInt(seedPart.slice(2,4), radix) / (radix ** 2),
+                        maxLevel * parseInt(seedPart.slice(4,6), radix) / (radix ** 2),
+                        parseInt(seedPart.slice(6,7), radix) / radix,
+                        parseInt(seedPart.slice(7,8), radix) / radix,
+                        parseInt(seedPart.slice(8,9), radix) / radix,
+                        parseInt(seedPart.slice(8,9), radix) / radix,
+                    ])
+                );
+
+                index += camelInformationLength;
+            };
+
+            new Array(30).forEach(quality => populateCamelArray(camels));
+        }
+
         let easyCamelCount = 10;
         let mediumCamelCount = 10;
         let hardCamelCount = 10;
@@ -21,7 +49,7 @@ class CamelStable {
         let mediumCamels: Camel[] = [];
         let hardCamels: Camel[] = [];
 
-        const populateCamelArray = (quality: InitCamelQuality, camelArray: Camel[]) => {
+        const populateQualityCamelArray = (quality: InitCamelQuality, camelArray: Camel[]) => {
             const radix = 36
             const seedPart = seed.slice(index * camelInformationLength, (1 + index) * camelInformationLength);
 
@@ -40,9 +68,9 @@ class CamelStable {
             index += camelInformationLength;
         };
 
-        new Array(easyCamelCount).fill(InitCamelQuality.High).forEach(quality => populateCamelArray(quality, easyCamels));
-        new Array(mediumCamelCount).fill(InitCamelQuality.Cpu1).forEach(quality => populateCamelArray(quality, mediumCamels));
-        new Array(hardCamelCount).fill(InitCamelQuality.Cpu5).forEach(quality => populateCamelArray(quality, hardCamels));
+        new Array(easyCamelCount).fill(InitCamelQuality.High).forEach(quality => populateQualityCamelArray(quality, easyCamels));
+        new Array(mediumCamelCount).fill(InitCamelQuality.Cpu1).forEach(quality => populateQualityCamelArray(quality, mediumCamels));
+        new Array(hardCamelCount).fill(InitCamelQuality.Cpu5).forEach(quality => populateQualityCamelArray(quality, hardCamels));
     }
 
     public static GetGeneralWaste: () => Camel = () => {

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -22,17 +22,18 @@ class CamelStable {
         let hardCamels: Camel[] = [];
 
         const populateCamelArray = (quality: InitCamelQuality, camelArray: Camel[]) => {
+            const radix = 36
             const seedPart = seed.slice(index * camelInformationLength, (1 + index) * camelInformationLength);
 
             camelArray.push(
                 this._camelCreator.createSeededCamel([
-                    ((quality + 1) / 10) * parseInt(seed.slice(0,2), 36) / (36 ** 2),
-                    parseInt(seedPart.slice(2,4), 36) / (36 ** 2),
-                    parseInt(seedPart.slice(4,6), 36) / (36 ** 2),
-                    parseInt(seedPart.slice(6,7), 36) / 36,
-                    parseInt(seedPart.slice(7,8), 36) / 36,
-                    parseInt(seedPart.slice(8,9), 36) / 36,
-                    parseInt(seedPart.slice(8,9), 36) / 36
+                    ((quality + 1) / 10) * parseInt(seedPart.slice(0,2), radix) / (radix ** 2),
+                    ((quality + 1) / 10) * parseInt(seedPart.slice(2,4), radix) / (radix ** 2),
+                    ((quality + 1) / 10) * parseInt(seedPart.slice(4,6), radix) / (radix ** 2),
+                    parseInt(seedPart.slice(6,7), radix) / radix,
+                    parseInt(seedPart.slice(7,8), radix) / radix,
+                    parseInt(seedPart.slice(8,9), radix) / radix,
+                    parseInt(seedPart.slice(8,9), radix) / radix,
                 ])
             );
 

--- a/global/camel-stable.ts
+++ b/global/camel-stable.ts
@@ -24,22 +24,22 @@ class CamelStable {
         if (firstTimeSetUp) {
             uniformCenters.forEach(center => {
 
-                const agility = this.generateRandomNumber(center, variation); 
-                const sprintSpeed = this.generateRandomNumber(center, variation); 
-                const stamina = this.generateRandomNumber(center, variation); 
-                const colour = this.generateSeed(1);
-                const name1 = this.generateSeed(1);
-                const name2 = this.generateSeed(1);
-                const temperament = this.generateSeed(1); // unused
+                const agility = this.generateRandomNumber(center, variation);
+                const sprintSpeed = this.generateRandomNumber(center, variation);
+                const stamina = this.generateRandomNumber(center, variation);
+                const colour = parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix;
+                const name1 = parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix;
+                const name2 = parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix;
+                const temperament = parseInt(this.generateSeed(1), this._seedRadix) / this._seedRadix; // unused
 
                 const camel = this._camelCreator.createSeededCamel([
                     agility,
                     sprintSpeed,
                     stamina,
-                    parseInt(colour, this._seedRadix) / this._seedRadix,
-                    parseInt(name1, this._seedRadix) / this._seedRadix,
-                    parseInt(name2, this._seedRadix) / this._seedRadix,
-                    parseInt(temperament, this._seedRadix) / this._seedRadix,
+                    colour,
+                    name1,
+                    name2,
+                    temperament
                 ]);
 
                 this.camels.push(camel);

--- a/global/game-state.ts
+++ b/global/game-state.ts
@@ -6,18 +6,20 @@ interface GameStateObject {
     lastUsedId: number,
     cashMoney: number,
     calendar: Calendar,
-    scrolls: Scroll[]
+    scrolls: Scroll[],
+    stableSeed: string
 }
 
 class GameState {
     // Update this whenever a new gamestate version is created
-    private static _version: number = 3;
+    private static _version: number = 4;
 
     // Camel
     public static camel: Camel | undefined;
     public static camels: Camel[] = [];
     public static secondsPassed: number = 0; // done
     public static oldTimeStamp: number = 0; // done
+    public static stableSeed: string = "";
 
     // Calendar
     public static calendar: Calendar;
@@ -39,7 +41,8 @@ class GameState {
             lastUsedId: GameState.lastUsedId,
             cashMoney: GameState.cashMoney,
             calendar: GameState.calendar,
-            scrolls: GameState.scrolls
+            scrolls: GameState.scrolls,
+            stableSeed: GameState.stableSeed
         }
         const gameStateString = JSON.stringify(gameStateObject);
         localStorage.setItem(this.getItemKey(), gameStateString);
@@ -80,6 +83,7 @@ class GameState {
         GameState.calendar = new Calendar(gameState.calendar.Day, gameState.calendar.Season);
         debugger;
         GameState.scrolls = gameState.scrolls;
+        GameState.stableSeed = gameState.stableSeed;
     }
 
     private static loadCamel(camelCreator: CamelCreator, serialisedCamel: Camel) {

--- a/global/global-services.ts
+++ b/global/global-services.ts
@@ -2,4 +2,5 @@ interface GlobalServices {
     musicService: MusicService,
     navigatorService: NavigatorService,
     camelCreator: CamelCreator
+    camelStable: CamelStable
 }

--- a/global/startup.ts
+++ b/global/startup.ts
@@ -47,11 +47,13 @@ class Startup {
         const levelCurveFactor = new LevelCurveFactory();
         const camelSkillCreator = new CamelSkillCreator(levelCurveFactor);
         const camelCreator = new CamelCreator(camelPropertyGenerator, camelSkillCreator);
+        const camelStable = new CamelStable(camelCreator);
 
         return {
             musicService,
             navigatorService,
-            camelCreator
+            camelCreator,
+            camelStable
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -3387,20 +3387,20 @@ class RaceManagement {
         }
     }
     createRace(raceLength, prizeCashMoney, raceSize, difficulty) {
-        let competitorQuality = 0; // Average level of competitors
+        let averageCompetitorLevel = 0;
         if (difficulty === Difficulty.Easy) {
-            competitorQuality = 40;
+            averageCompetitorLevel = 20;
         }
         else if (difficulty === Difficulty.Normal) {
-            competitorQuality = 50;
+            averageCompetitorLevel = 50;
         }
         else {
-            competitorQuality = 90;
+            averageCompetitorLevel = 80;
         }
         const trackCreator = new RaceTrackCreator();
         const track = trackCreator.createTrack(raceLength);
         const race = new Race(raceLength, track, prizeCashMoney, difficulty);
-        this.addCpuCamelsToRace(raceSize, competitorQuality, race);
+        this.addCpuCamelsToRace(raceSize, averageCompetitorLevel, race);
         return race;
     }
     startRace(race) {

--- a/main.js
+++ b/main.js
@@ -1153,8 +1153,10 @@ class CamelStable {
             firstTimeSetUp = true;
         }
         let index = 0;
-        const variation = 30;
-        const uniformCenters = Array.from(new Array(this._numberOfCamels), (e, i) => (100 / this._numberOfCamels) * (i + 1));
+        const variation = 20;
+        const minimumLevel = 5;
+        const maximumLevel = 100;
+        const uniformCenters = Array.from(new Array(this._numberOfCamels), (e, i) => minimumLevel + ((maximumLevel - minimumLevel) / this._numberOfCamels) * (i));
         if (firstTimeSetUp) {
             uniformCenters.forEach(center => {
                 const agility = this.generateRandomNumber(center, variation);

--- a/main.js
+++ b/main.js
@@ -3071,12 +3071,15 @@ class LeaderboardService {
         const camelService = new CanvasCamelService(this.ctx);
         camelService.drawCamelScreenCoords(GlobalStaticConstants.innerWidth - 150, 70 - heightOffset * 10, 10, camel.camel.colour);
         this.ctx.fillStyle = "#96876e";
-        if (this.isCamelUserOwned(camel.camel)) {
-            this.ctx.fillStyle = "#96876e";
-            this.ctx.fillText(camel.camel.name, GlobalStaticConstants.innerWidth - 100, 59 - heightOffset * 10);
-        }
-        this.ctx.fillStyle = "#000";
         this.ctx.font = "10pt Garamond";
+        this.ctx.save();
+        if (this.isCamelUserOwned(camel.camel)) {
+            this.ctx.fillStyle = GlobalStaticConstants.highlightColour;
+            this.ctx.font = "bold 10pt Garamond";
+        }
+        this.ctx.fillText(camel.camel.name, GlobalStaticConstants.innerWidth - 100, 59 - heightOffset * 10);
+        this.ctx.restore();
+        this.ctx.fillStyle = "#000";
         const completionPercentage = Math.min(1, Math.round(camel.completionPercentage * 100) / 100);
         this.ctx.beginPath();
         this.ctx.fillStyle = "#fff";

--- a/main.js
+++ b/main.js
@@ -1213,7 +1213,7 @@ class CamelStable {
     generateSeed(length = 700, radix = 36) {
         return "x".repeat(length).replace(/x/g, (char) => Math.floor(Math.random() * radix).toString(radix));
     }
-    generateRandomNumber(center, plusMinusRange, max = 100, min = 0) {
+    generateRandomNumber(center, plusMinusRange, min = 1, max = 100) {
         const randValue = center + ((Math.random()) * 2 - 1) * plusMinusRange;
         return Math.max(min, Math.min(max, randValue));
     }
@@ -2152,9 +2152,9 @@ class CamelCreator {
         return new Camel(serialisedCamel.id, camelInitProperties);
     }
     createSeededCamel(seeds) {
-        const agility = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.agility, Math.ceil(seeds[0] * 100));
-        const sprintSpeed = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.sprintSpeed, Math.ceil(seeds[1] * 100));
-        const stamina = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.stamina, Math.ceil(seeds[2] * 100));
+        const agility = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.agility, Math.ceil(seeds[0]));
+        const sprintSpeed = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.sprintSpeed, Math.ceil(seeds[1]));
+        const stamina = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.stamina, Math.ceil(seeds[2]));
         const camelInitProperties = {
             colour: this._camelPropertyGenerator.generateSeededColour(seeds[3]),
             name: this._camelPropertyGenerator.generateSeededName(seeds[4], seeds[5]),

--- a/main.js
+++ b/main.js
@@ -2177,7 +2177,7 @@ class CamelCreator {
         encodedString += camel.sprintSpeed.level.toString(radix).padStart(2, "0");
         encodedString += camel.stamina.level.toString(radix).padStart(2, "0");
         // colour
-        encodedString += (parseInt(camel.colour.substring(1, 7), 16) / 13000).toString(36);
+        encodedString += Math.round(parseInt(camel.colour.substring(1, 7), 16) / (16 ** 6 / 36)).toString(36);
         // name
         encodedString += this._camelPropertyGenerator.generateSeedFromName(camel.name);
         return encodedString;
@@ -2200,7 +2200,7 @@ class CamelPropertyGenerator {
         return this.generateSeededColour(Math.random());
     }
     generateSeededColour(seed) {
-        return '#' + (0x000000 + seed * 0x32c8).toString(16);
+        return '#' + (0x000000 + Math.floor(seed * 36) * 0x71c71).toString(16);
     }
     generateName() {
         return this.generateSeededName(Math.random(), Math.random());
@@ -3366,15 +3366,6 @@ class RaceManagement {
         const racingCamel = new RacingCamel(camel);
         race.racingCamels.push(racingCamel);
     }
-    // private addCpuCamelsToRace(
-    //     raceSize: number,
-    //     competitorQuality: InitCamelQuality,
-    //     race: Race) {
-    //     for (let i = 0; i < raceSize; i++) {
-    //         const competitorCamel = this._camelCreator.createRandomCamelWithQuality(competitorQuality);
-    //         this.addCamelToRace(competitorCamel, race);
-    //     }
-    // }
     addCpuCamelsToRace(raceSize, raceDifficulty, race) {
         globalServices.camelStable.populateStable();
         let sortedCamels = globalServices.camelStable.camels

--- a/main.js
+++ b/main.js
@@ -1182,19 +1182,18 @@ class CamelStable {
         }
         const populateCamelArray = (camelArray) => {
             const seedPart = GameState.stableSeed.slice(index * this._camelInformationLength, (1 + index) * this._camelInformationLength);
-            const maxLevel = (new DefaultLevelCurve()).maxSkillLevel;
             camelArray.push(this._camelCreator.createSeededCamel([
-                maxLevel * parseInt(seedPart.slice(0, 2), this._seedRadix) / (this._seedRadix ** 2),
-                maxLevel * parseInt(seedPart.slice(2, 4), this._seedRadix) / (this._seedRadix ** 2),
-                maxLevel * parseInt(seedPart.slice(4, 6), this._seedRadix) / (this._seedRadix ** 2),
+                parseInt(seedPart.slice(0, 2), this._seedRadix),
+                parseInt(seedPart.slice(2, 4), this._seedRadix),
+                parseInt(seedPart.slice(4, 6), this._seedRadix),
                 parseInt(seedPart.slice(6, 7), this._seedRadix) / this._seedRadix,
                 parseInt(seedPart.slice(7, 8), this._seedRadix) / this._seedRadix,
                 parseInt(seedPart.slice(8, 9), this._seedRadix) / this._seedRadix,
                 parseInt(seedPart.slice(9, 10), this._seedRadix) / this._seedRadix,
             ]));
-            index += this._camelInformationLength;
+            index += 1;
         };
-        new Array(this._numberOfCamels).forEach(e => populateCamelArray(this.camels));
+        new Array(this._numberOfCamels).fill(1).forEach(e => populateCamelArray(this.camels));
         return;
     }
     static GetGeneralWaste = () => {
@@ -2179,7 +2178,7 @@ class CamelCreator {
         encodedString += camel.sprintSpeed.level.toString(radix).padStart(2, "0");
         encodedString += camel.stamina.level.toString(radix).padStart(2, "0");
         // colour
-        encodedString += Math.round(parseInt(camel.colour.substring(1, 7), 16) / (16 ** 6 / 36)).toString(36);
+        encodedString += Math.round(parseInt(camel.colour.substring(1, 7), 16) / (16 ** 6 / radix)).toString(radix);
         // name
         encodedString += this._camelPropertyGenerator.generateSeedFromName(camel.name);
         return encodedString;

--- a/management/camel-creation/camel-creator.ts
+++ b/management/camel-creation/camel-creator.ts
@@ -94,4 +94,24 @@ class CamelCreator {
 
         return new Camel(++GameState.lastUsedId, camelInitProperties);
     }
+
+    
+
+    public createSeedFromCamel(camel: Camel): string {
+        const radix = 36;
+        let encodedString = "";
+
+        // skills
+        encodedString += camel.agility.level.toString(radix).padStart(2,"0");
+        encodedString += camel.sprintSpeed.level.toString(radix).padStart(2,"0");
+        encodedString += camel.stamina.level.toString(radix).padStart(2,"0");
+
+        // colour
+        encodedString += (parseInt(camel.colour.substring(1,7), 16) / 13000).toString(36);
+
+        // name
+        encodedString += this._camelPropertyGenerator.generateSeedFromName(camel.name);
+        
+        return encodedString;
+    }
 }

--- a/management/camel-creation/camel-creator.ts
+++ b/management/camel-creation/camel-creator.ts
@@ -107,7 +107,7 @@ class CamelCreator {
         encodedString += camel.stamina.level.toString(radix).padStart(2,"0");
 
         // colour
-        encodedString += (parseInt(camel.colour.substring(1,7), 16) / 13000).toString(36);
+        encodedString += Math.round(parseInt(camel.colour.substring(1,7), 16) / (16**6 / 36)).toString(36);
 
         // name
         encodedString += this._camelPropertyGenerator.generateSeedFromName(camel.name);

--- a/management/camel-creation/camel-creator.ts
+++ b/management/camel-creation/camel-creator.ts
@@ -107,7 +107,7 @@ class CamelCreator {
         encodedString += camel.stamina.level.toString(radix).padStart(2,"0");
 
         // colour
-        encodedString += Math.round(parseInt(camel.colour.substring(1,7), 16) / (16**6 / 36)).toString(36);
+        encodedString += Math.round(parseInt(camel.colour.substring(1,7), 16) / (16**6 / radix)).toString(radix);
 
         // name
         encodedString += this._camelPropertyGenerator.generateSeedFromName(camel.name);

--- a/management/camel-creation/camel-creator.ts
+++ b/management/camel-creation/camel-creator.ts
@@ -75,9 +75,9 @@ class CamelCreator {
     public createSeededCamel(
         seeds: [number, number, number, number, number, number, number]
     ): Camel {
-        const agility = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.agility, Math.ceil(seeds[0] * 100));
-        const sprintSpeed = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.sprintSpeed, Math.ceil(seeds[1] * 100));
-        const stamina = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.stamina, Math.ceil(seeds[2] * 100));
+        const agility = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.agility, Math.ceil(seeds[0]));
+        const sprintSpeed = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.sprintSpeed, Math.ceil(seeds[1]));
+        const stamina = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.stamina, Math.ceil(seeds[2]));
 
         const camelInitProperties: CamelInitProperties = {
             colour: this._camelPropertyGenerator.generateSeededColour(seeds[3]),

--- a/management/camel-creation/camel-creator.ts
+++ b/management/camel-creation/camel-creator.ts
@@ -29,6 +29,31 @@ class CamelCreator {
         return camel;
     }
 
+    public createCamel(
+        agilityLevel: number,
+        sprintSpeedLevel: number,
+        staminaLevel: number,
+    ): Camel {
+        const agility = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.agility, agilityLevel);
+        const sprintSpeed = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.sprintSpeed, sprintSpeedLevel);
+        const stamina = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.stamina, staminaLevel);
+
+        const camelInitProperties: CamelInitProperties = {
+            colour: this._camelPropertyGenerator.generateColour(),
+            name: this._camelPropertyGenerator.generateName(),
+            skills: {
+                agility: agility,
+                sprintSpeed: sprintSpeed,
+                stamina: stamina,
+            },
+            temperament: this._camelPropertyGenerator.generateTemperament(),
+            unspentXp: 0,
+            achievementsUnlocked: 0,
+        }
+
+        return new Camel(++GameState.lastUsedId, camelInitProperties);
+    }
+
     public createCamelFromSerialisedCamel(serialisedCamel: Camel): Camel {
         const camelInitProperties: CamelInitProperties = {
             colour: serialisedCamel.colour,
@@ -44,5 +69,29 @@ class CamelCreator {
         }
 
         return new Camel(serialisedCamel.id, camelInitProperties);
+    }
+
+    
+    public createSeededCamel(
+        seeds: [number, number, number, number, number, number, number]
+    ): Camel {
+        const agility = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.agility, Math.ceil(seeds[0] * 100));
+        const sprintSpeed = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.sprintSpeed, Math.ceil(seeds[1] * 100));
+        const stamina = this._camelSkillCreator.generateSkillWithLevel(CamelSkillType.stamina, Math.ceil(seeds[2] * 100));
+
+        const camelInitProperties: CamelInitProperties = {
+            colour: this._camelPropertyGenerator.generateSeededColour(seeds[3]),
+            name: this._camelPropertyGenerator.generateSeededName(seeds[4], seeds[5]),
+            skills: {
+                agility: agility,
+                sprintSpeed: sprintSpeed,
+                stamina: stamina,
+            },
+            temperament: this._camelPropertyGenerator.generateTemperament(),
+            unspentXp: 0,
+            achievementsUnlocked: 0,
+        }
+
+        return new Camel(++GameState.lastUsedId, camelInitProperties);
     }
 }

--- a/management/camel-creation/camel-property-generator.ts
+++ b/management/camel-creation/camel-property-generator.ts
@@ -1,9 +1,17 @@
-class CamelPropertyGenerator{
+class CamelPropertyGenerator {
     public generateColour(): string {
-        return '#' + (0x1000000 + Math.random() * 0xffffff).toString(16).substring(1, 7);
+        return this.generateSeededColour(Math.random());
+    }
+
+    public generateSeededColour(seed: number): string {
+        return '#' + (0x1000000 + seed * 0xffffff).toString(16).substring(1, 7);
     }
 
     public generateName(): string {
+        return this.generateSeededName(Math.random(), Math.random());
+    }
+
+    public generateSeededName(adjectiveSeed: number, nounSeed: number): string {
         const adjectives = [
             "Sandy", "Dusty", "Golden", "Majestic", "Spotted",
             "Whirling", "Blazing", "Silent", "Radiant", "Breezy",
@@ -18,14 +26,18 @@ class CamelPropertyGenerator{
             "Sultan", "Talisman", "Treasure", "Zephyr", "Zodiac"
         ];
 
-        const randomAdjective = adjectives[Math.floor(Math.random() * adjectives.length)];
-        const randomNoun = nouns[Math.floor(Math.random() * nouns.length)];
+        const randomAdjective = adjectives[Math.floor(adjectiveSeed * adjectives.length)];
+        const randomNoun = nouns[Math.floor(nounSeed * nouns.length)];
 
         return randomAdjective + " " + randomNoun;
     }
 
     public generateTemperament(): CamelTemperament {
-        if (Math.random() < 0.25) {
+        return this.generateSeededTemperament(Math.random());
+    }
+
+    public generateSeededTemperament(seed: number): CamelTemperament {
+        if (seed < 0.25) {
             return CamelTemperament.Aggressive;
         } else if (Math.random() < 0.5) {
             return CamelTemperament.Temperamental;

--- a/management/camel-creation/camel-property-generator.ts
+++ b/management/camel-creation/camel-property-generator.ts
@@ -1,10 +1,24 @@
 class CamelPropertyGenerator {
+    private nameAjectives =  [
+        "Sandy", "Dusty", "Golden", "Majestic", "Spotted",
+        "Whirling", "Blazing", "Silent", "Radiant", "Breezy",
+        "Amber", "Crimson", "Harmony", "Marble", "Opal",
+        "Princess", "Sahara", "Shadow", "Tawny", "Whisper"
+    ];
+
+    private nameNouns =  [
+        "Desert", "Oasis", "Pyramid", "Mirage", "Nomad",
+        "Sunset", "Sahara", "Dune", "Caravan", "Cactus",
+        "Jewel", "Moon", "Oracle", "Sphinx", "Spirit",
+        "Sultan", "Talisman", "Treasure", "Zephyr", "Zodiac"
+    ];
+
     public generateColour(): string {
         return this.generateSeededColour(Math.random());
     }
 
     public generateSeededColour(seed: number): string {
-        return '#' + (0x1000000 + seed * 0xffffff).toString(16).substring(1, 7);
+        return '#' + (0x000000 + seed * 0x32c8).toString(16);
     }
 
     public generateName(): string {
@@ -12,24 +26,18 @@ class CamelPropertyGenerator {
     }
 
     public generateSeededName(adjectiveSeed: number, nounSeed: number): string {
-        const adjectives = [
-            "Sandy", "Dusty", "Golden", "Majestic", "Spotted",
-            "Whirling", "Blazing", "Silent", "Radiant", "Breezy",
-            "Amber", "Crimson", "Harmony", "Marble", "Opal",
-            "Princess", "Sahara", "Shadow", "Tawny", "Whisper"
-        ];
-
-        const nouns = [
-            "Desert", "Oasis", "Pyramid", "Mirage", "Nomad",
-            "Sunset", "Sahara", "Dune", "Caravan", "Cactus",
-            "Jewel", "Moon", "Oracle", "Sphinx", "Spirit",
-            "Sultan", "Talisman", "Treasure", "Zephyr", "Zodiac"
-        ];
-
-        const randomAdjective = adjectives[Math.floor(adjectiveSeed * adjectives.length)];
-        const randomNoun = nouns[Math.floor(nounSeed * nouns.length)];
+        const randomAdjective = this.nameAjectives[Math.floor(adjectiveSeed * this.nameAjectives.length)];
+        const randomNoun = this.nameNouns[Math.floor(nounSeed * this.nameNouns.length)];
 
         return randomAdjective + " " + randomNoun;
+    }
+
+    public generateSeedFromName(name: string): string {
+        let seed = "";
+        seed += this.nameAjectives.indexOf(name.split(" ")[0]);
+        seed += this.nameNouns.indexOf(name.split(" ")[1]);
+
+        return seed;
     }
 
     public generateTemperament(): CamelTemperament {

--- a/management/camel-creation/camel-property-generator.ts
+++ b/management/camel-creation/camel-property-generator.ts
@@ -18,7 +18,7 @@ class CamelPropertyGenerator {
     }
 
     public generateSeededColour(seed: number): string {
-        return '#' + (0x000000 + seed * 0x32c8).toString(16);
+        return '#' + (0x000000 + Math.floor(seed * 36) * 0x71c71).toString(16);
     }
 
     public generateName(): string {

--- a/management/camel-creation/camel-skill-creator.ts
+++ b/management/camel-creation/camel-skill-creator.ts
@@ -21,4 +21,13 @@ class CamelSkillCreator {
         
         return new CamelSkill(serialisedSkill.skillType, levelCurve, serialisedSkill.potential, xp);
     }
+
+    public generateSkillWithLevel(
+        skillType: CamelSkillType, 
+        level: number): CamelSkill {
+            
+        const levelCurve = this._levelCurveFactory.getDefaultLevelCurve();
+        
+        return new CamelSkill(skillType, levelCurve, level, levelCurve.getXpRequiredForLevel(level, level));
+    }
 }

--- a/management/camel-creation/camel.ts
+++ b/management/camel-creation/camel.ts
@@ -74,9 +74,9 @@ class Camel {
         else return 'Legendary camel in the making'
     }
 
-    public get levelTotal(): number {
-        return this.agility.level +
+    public get levelAverage(): number {
+        return (this.agility.level +
             this.sprintSpeed.level +
-            this.stamina.level;
+            this.stamina.level)/3;
     }
 }

--- a/management/camel-creation/camel.ts
+++ b/management/camel-creation/camel.ts
@@ -39,8 +39,8 @@ class Camel {
 
     public get level(): number {
         const skillLevels = [
-            this.agility.level, 
-            this.sprintSpeed.level, 
+            this.agility.level,
+            this.sprintSpeed.level,
             this.stamina.level];
 
         const skillLevelSum = skillLevels.reduce((partialSum, newValue) => partialSum + newValue, 0);
@@ -50,8 +50,8 @@ class Camel {
 
     public get potentialLevel(): number {
         const potentialSkillLevels = [
-            this.agility.potential, 
-            this.sprintSpeed.potential, 
+            this.agility.potential,
+            this.sprintSpeed.potential,
             this.stamina.potential];
 
         const skillLevelSum = potentialSkillLevels.reduce((partialSum, newValue) => partialSum + newValue, 0);
@@ -62,15 +62,21 @@ class Camel {
     public get potentialDescription(): string {
         const potentialLevel = this.potentialLevel;
 
-        if(potentialLevel <= 10) return 'Dismal underachiever';
-        else if(potentialLevel <= 20) return 'Dismal underachiever';
-        else if(potentialLevel <= 30) return 'Struggling competitor';
-        else if(potentialLevel <= 40) return 'Modest hopeless case';
-        else if(potentialLevel <= 50) return 'Developing talent';
-        else if(potentialLevel <= 60) return 'Breakthrough prospect';
-        else if(potentialLevel <= 70) return 'Frontrunner in training';
-        else if(potentialLevel <= 80) return 'Elite championship aspirant';
-        else if(potentialLevel <= 90) return 'Future racing star';
+        if (potentialLevel <= 10) return 'Dismal underachiever';
+        else if (potentialLevel <= 20) return 'Dismal underachiever';
+        else if (potentialLevel <= 30) return 'Struggling competitor';
+        else if (potentialLevel <= 40) return 'Modest hopeless case';
+        else if (potentialLevel <= 50) return 'Developing talent';
+        else if (potentialLevel <= 60) return 'Breakthrough prospect';
+        else if (potentialLevel <= 70) return 'Frontrunner in training';
+        else if (potentialLevel <= 80) return 'Elite championship aspirant';
+        else if (potentialLevel <= 90) return 'Future racing star';
         else return 'Legendary camel in the making'
+    }
+
+    public get levelTotal(): number {
+        return this.agility.level +
+            this.sprintSpeed.level +
+            this.stamina.level;
     }
 }

--- a/management/skills/default-level-curve.ts
+++ b/management/skills/default-level-curve.ts
@@ -3,7 +3,7 @@ class DefaultLevelCurve implements LevelCurve {
 
     public get maxSkillLevel() { return 99; }
 
-    public getXpRequiredForLevel(level: number, potential: number) {
+    public getXpRequiredForLevel(level: number, potential: number = 0) {
         return (level - 1) * 100;
     }
 

--- a/map/map-overview.ts
+++ b/map/map-overview.ts
@@ -38,9 +38,6 @@ class MapOverview {
     }
 
     public static load() {
-        console.log(`Height: ${GlobalStaticConstants.innerHeight}`);
-        console.log(`Width: ${GlobalStaticConstants.innerWidth}`);
-
         // Set up canvas
         CanvasService.bringCanvasToTop(CanvasNames.MapOverview);
         CanvasService.showCanvas(CanvasNames.MapOverview);

--- a/racing/leaderboard-service.ts
+++ b/racing/leaderboard-service.ts
@@ -55,14 +55,17 @@ class LeaderboardService {
 
 		camelService.drawCamelScreenCoords(GlobalStaticConstants.innerWidth - 150, 70 - heightOffset * 10, 10, camel.camel.colour);
 		this.ctx.fillStyle = "#96876e";
+		this.ctx.font = "10pt Garamond";
 
+		this.ctx.save();
 		if (this.isCamelUserOwned(camel.camel)) {
-			this.ctx.fillStyle = "#96876e";
-			this.ctx.fillText(camel.camel.name, GlobalStaticConstants.innerWidth - 100, 59 - heightOffset * 10);
-		}
+			this.ctx.fillStyle = GlobalStaticConstants.highlightColour;
+			this.ctx.font = "bold 10pt Garamond";
+		} 
+		this.ctx.fillText(camel.camel.name, GlobalStaticConstants.innerWidth - 100, 59 - heightOffset * 10);
+		this.ctx.restore();
 
 		this.ctx.fillStyle = "#000";
-		this.ctx.font = "10pt Garamond";
 		const completionPercentage = Math.min(1, Math.round(camel.completionPercentage * 100) / 100);
 		this.ctx.beginPath();
 		this.ctx.fillStyle = "#fff";

--- a/racing/race-managment.ts
+++ b/racing/race-managment.ts
@@ -41,14 +41,14 @@ class RaceManagement {
         prizeCashMoney: number,
         raceSize: number,
         difficulty: Difficulty): Race {
-        let competitorQuality = 0; // Average level of competitors
+        let averageCompetitorLevel = 0;
 
         if (difficulty === Difficulty.Easy) {
-            competitorQuality = 40;
+            averageCompetitorLevel = 20;
         } else if (difficulty === Difficulty.Normal) {
-            competitorQuality = 50;
+            averageCompetitorLevel = 50;
         } else {
-            competitorQuality = 90;
+            averageCompetitorLevel = 80;
         }
 
         const trackCreator = new RaceTrackCreator();
@@ -56,7 +56,7 @@ class RaceManagement {
 
         const race = new Race(raceLength, track, prizeCashMoney, difficulty);
 
-        this.addCpuCamelsToRace(raceSize, competitorQuality, race);
+        this.addCpuCamelsToRace(raceSize, averageCompetitorLevel, race);
 
         return race;
     }

--- a/racing/race-managment.ts
+++ b/racing/race-managment.ts
@@ -10,17 +10,6 @@ class RaceManagement {
         race.racingCamels.push(racingCamel);
     }
 
-    // private addCpuCamelsToRace(
-    //     raceSize: number,
-    //     competitorQuality: InitCamelQuality,
-    //     race: Race) {
-    //     for (let i = 0; i < raceSize; i++) {
-    //         const competitorCamel = this._camelCreator.createRandomCamelWithQuality(competitorQuality);
-
-    //         this.addCamelToRace(competitorCamel, race);
-    //     }
-    // }
-
     private addCpuCamelsToRace(
         raceSize: number,
         raceDifficulty: number,

--- a/racing/race-managment.ts
+++ b/racing/race-managment.ts
@@ -10,14 +10,29 @@ class RaceManagement {
         race.racingCamels.push(racingCamel);
     }
 
+    // private addCpuCamelsToRace(
+    //     raceSize: number,
+    //     competitorQuality: InitCamelQuality,
+    //     race: Race) {
+    //     for (let i = 0; i < raceSize; i++) {
+    //         const competitorCamel = this._camelCreator.createRandomCamelWithQuality(competitorQuality);
+
+    //         this.addCamelToRace(competitorCamel, race);
+    //     }
+    // }
+
     private addCpuCamelsToRace(
         raceSize: number,
-        competitorQuality: InitCamelQuality,
+        raceDifficulty: number,
         race: Race) {
-        for (let i = 0; i < raceSize; i++) {
-            const competitorCamel = this._camelCreator.createRandomCamelWithQuality(competitorQuality);
+            globalServices.camelStable.populateStable();
+            let sortedCamels = globalServices.camelStable.camels
+                .map(c => c) // copy array
+                .sort((c1, c2) => Math.abs(c1.levelAverage - raceDifficulty) - Math.abs(c2.levelAverage - raceDifficulty));
 
-            this.addCamelToRace(competitorCamel, race);
+        for (let i = 0; i < raceSize; i++) {
+            if (sortedCamels.length === 0) break;
+            this.addCamelToRace(sortedCamels.shift() as Camel, race);
         }
     }
 
@@ -26,14 +41,14 @@ class RaceManagement {
         prizeCashMoney: number,
         raceSize: number,
         difficulty: Difficulty): Race {
-        let competitorQuality: InitCamelQuality;
+        let competitorQuality = 0; // Average level of competitors
 
         if (difficulty === Difficulty.Easy) {
-            competitorQuality = InitCamelQuality.High;
+            competitorQuality = 40;
         } else if (difficulty === Difficulty.Normal) {
-            competitorQuality = InitCamelQuality.Cpu1;
+            competitorQuality = 50;
         } else {
-            competitorQuality = InitCamelQuality.Cpu5;
+            competitorQuality = 90;
         }
 
         const trackCreator = new RaceTrackCreator();


### PR DESCRIPTION
Add persistent AI camels, with names and stuff. Stores them encoded in base36 in GameState.
Races are now populated by using an avg. level rather than quality, and drawn from camels who live in camelStable.

Old save files can be used by adding camelStable with an empty string.